### PR TITLE
fix typo in protocol PlaySetSlot

### DIFF
--- a/src/v1_15_2.rs
+++ b/src/v1_15_2.rs
@@ -181,7 +181,7 @@ define_protocol!(578, Packet578, RawPacket578, RawPacket578Body, Packet578Kind =
     },
     PlaySetSlot, 0x17, Play, ClientBound => PlaySetSlotSpec {
         window_id: u8,
-        slow: i16,
+        slot: i16,
         slot_data: Slot
     },
     PlaySetCooldown, 0x18, Play, ClientBound => PlaySetCooldownSpec {

--- a/src/v1_16_3.rs
+++ b/src/v1_16_3.rs
@@ -173,7 +173,7 @@ define_protocol!(753, Packet753, RawPacket753, RawPacket753Body, Packet753Kind =
     },
     PlaySetSlot, 0x15, Play, ClientBound => PlaySetSlotSpec {
         window_id: u8,
-        slow: i16,
+        slot: i16,
         slot_data: Slot
     },
     PlaySetCooldown, 0x16, Play, ClientBound => PlaySetCooldownSpec {


### PR DESCRIPTION
Fix the typo in the field of PlaySetSlot 'slow' → 'slot'.

Beware, it will break existing code.

Fix #7 